### PR TITLE
Lib AutoSettingsFiles bug fix

### DIFF
--- a/mods/AIs dont attack/Client_PresentConfigureUI.lua
+++ b/mods/AIs dont attack/Client_PresentConfigureUI.lua
@@ -255,9 +255,9 @@ function cpcDoSetting(setting, vert)
 		createHelpBtn(horz, vert2, setting);
 
 		if setting.inputType == 'text' then
-			makeTextInput(setting, horz);
+			makeTextInput(setting, horz, initialSettingValue);
 		elseif setting.inputType == 'int' or setting.inputType == 'float' then
-			makeNumberInput(setting, horz);
+			makeNumberInput(setting, horz, initialSettingValue);
 		end
 	end
 end
@@ -388,7 +388,7 @@ function cpcDoSettingBoolSubsettings(setting, horz, vert)
 	subsettingEnabledOrDisabled();
 end
 
-function makeTextInput(setting, horz)
+function makeTextInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateTextInputField(horz).SetText(initialSettingValue);
 
 	if setting.placeholder then
@@ -400,7 +400,7 @@ function makeTextInput(setting, horz)
 	end
 end
 
-function makeNumberInput(setting, horz)
+function makeNumberInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateNumberInputField(horz);
 
 	if setting.inputType == 'float' then

--- a/mods/Advanced Card Distribution per player/Client_PresentConfigureUI.lua
+++ b/mods/Advanced Card Distribution per player/Client_PresentConfigureUI.lua
@@ -255,9 +255,9 @@ function cpcDoSetting(setting, vert)
 		createHelpBtn(horz, vert2, setting);
 
 		if setting.inputType == 'text' then
-			makeTextInput(setting, horz);
+			makeTextInput(setting, horz, initialSettingValue);
 		elseif setting.inputType == 'int' or setting.inputType == 'float' then
-			makeNumberInput(setting, horz);
+			makeNumberInput(setting, horz, initialSettingValue);
 		end
 	end
 end
@@ -388,7 +388,7 @@ function cpcDoSettingBoolSubsettings(setting, horz, vert)
 	subsettingEnabledOrDisabled();
 end
 
-function makeTextInput(setting, horz)
+function makeTextInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateTextInputField(horz).SetText(initialSettingValue);
 
 	if setting.placeholder then
@@ -400,7 +400,7 @@ function makeTextInput(setting, horz)
 	end
 end
 
-function makeNumberInput(setting, horz)
+function makeNumberInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateNumberInputField(horz);
 
 	if setting.inputType == 'float' then

--- a/mods/Custom Card Package 2/Client_PresentConfigureUI.lua
+++ b/mods/Custom Card Package 2/Client_PresentConfigureUI.lua
@@ -255,9 +255,9 @@ function cpcDoSetting(setting, vert)
 		createHelpBtn(horz, vert2, setting);
 
 		if setting.inputType == 'text' then
-			makeTextInput(setting, horz);
+			makeTextInput(setting, horz, initialSettingValue);
 		elseif setting.inputType == 'int' or setting.inputType == 'float' then
-			makeNumberInput(setting, horz);
+			makeNumberInput(setting, horz, initialSettingValue);
 		end
 	end
 end
@@ -388,7 +388,7 @@ function cpcDoSettingBoolSubsettings(setting, horz, vert)
 	subsettingEnabledOrDisabled();
 end
 
-function makeTextInput(setting, horz)
+function makeTextInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateTextInputField(horz).SetText(initialSettingValue);
 
 	if setting.placeholder then
@@ -400,7 +400,7 @@ function makeTextInput(setting, horz)
 	end
 end
 
-function makeNumberInput(setting, horz)
+function makeNumberInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateNumberInputField(horz);
 
 	if setting.inputType == 'float' then

--- a/mods/Random settings generator/Client_PresentConfigureUI.lua
+++ b/mods/Random settings generator/Client_PresentConfigureUI.lua
@@ -255,9 +255,9 @@ function cpcDoSetting(setting, vert)
 		createHelpBtn(horz, vert2, setting);
 
 		if setting.inputType == 'text' then
-			makeTextInput(setting, horz);
+			makeTextInput(setting, horz, initialSettingValue);
 		elseif setting.inputType == 'int' or setting.inputType == 'float' then
-			makeNumberInput(setting, horz);
+			makeNumberInput(setting, horz, initialSettingValue);
 		end
 	end
 end
@@ -388,7 +388,7 @@ function cpcDoSettingBoolSubsettings(setting, horz, vert)
 	subsettingEnabledOrDisabled();
 end
 
-function makeTextInput(setting, horz)
+function makeTextInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateTextInputField(horz).SetText(initialSettingValue);
 
 	if setting.placeholder then
@@ -400,7 +400,7 @@ function makeTextInput(setting, horz)
 	end
 end
 
-function makeNumberInput(setting, horz)
+function makeNumberInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateNumberInputField(horz);
 
 	if setting.inputType == 'float' then

--- a/mods/Surveillance Card+/Client_PresentConfigureUI.lua
+++ b/mods/Surveillance Card+/Client_PresentConfigureUI.lua
@@ -255,9 +255,9 @@ function cpcDoSetting(setting, vert)
 		createHelpBtn(horz, vert2, setting);
 
 		if setting.inputType == 'text' then
-			makeTextInput(setting, horz);
+			makeTextInput(setting, horz, initialSettingValue);
 		elseif setting.inputType == 'int' or setting.inputType == 'float' then
-			makeNumberInput(setting, horz);
+			makeNumberInput(setting, horz, initialSettingValue);
 		end
 	end
 end
@@ -388,7 +388,7 @@ function cpcDoSettingBoolSubsettings(setting, horz, vert)
 	subsettingEnabledOrDisabled();
 end
 
-function makeTextInput(setting, horz)
+function makeTextInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateTextInputField(horz).SetText(initialSettingValue);
 
 	if setting.placeholder then
@@ -400,7 +400,7 @@ function makeTextInput(setting, horz)
 	end
 end
 
-function makeNumberInput(setting, horz)
+function makeNumberInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateNumberInputField(horz);
 
 	if setting.inputType == 'float' then

--- a/mods/Swap Territories 2/Client_PresentConfigureUI.lua
+++ b/mods/Swap Territories 2/Client_PresentConfigureUI.lua
@@ -255,9 +255,9 @@ function cpcDoSetting(setting, vert)
 		createHelpBtn(horz, vert2, setting);
 
 		if setting.inputType == 'text' then
-			makeTextInput(setting, horz);
+			makeTextInput(setting, horz, initialSettingValue);
 		elseif setting.inputType == 'int' or setting.inputType == 'float' then
-			makeNumberInput(setting, horz);
+			makeNumberInput(setting, horz, initialSettingValue);
 		end
 	end
 end
@@ -388,7 +388,7 @@ function cpcDoSettingBoolSubsettings(setting, horz, vert)
 	subsettingEnabledOrDisabled();
 end
 
-function makeTextInput(setting, horz)
+function makeTextInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateTextInputField(horz).SetText(initialSettingValue);
 
 	if setting.placeholder then
@@ -400,7 +400,7 @@ function makeTextInput(setting, horz)
 	end
 end
 
-function makeNumberInput(setting, horz)
+function makeNumberInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateNumberInputField(horz);
 
 	if setting.inputType == 'float' then

--- a/mods/Wastelands+/Client_PresentConfigureUI.lua
+++ b/mods/Wastelands+/Client_PresentConfigureUI.lua
@@ -255,9 +255,9 @@ function cpcDoSetting(setting, vert)
 		createHelpBtn(horz, vert2, setting);
 
 		if setting.inputType == 'text' then
-			makeTextInput(setting, horz);
+			makeTextInput(setting, horz, initialSettingValue);
 		elseif setting.inputType == 'int' or setting.inputType == 'float' then
-			makeNumberInput(setting, horz);
+			makeNumberInput(setting, horz, initialSettingValue);
 		end
 	end
 end
@@ -388,7 +388,7 @@ function cpcDoSettingBoolSubsettings(setting, horz, vert)
 	subsettingEnabledOrDisabled();
 end
 
-function makeTextInput(setting, horz)
+function makeTextInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateTextInputField(horz).SetText(initialSettingValue);
 
 	if setting.placeholder then
@@ -400,7 +400,7 @@ function makeTextInput(setting, horz)
 	end
 end
 
-function makeNumberInput(setting, horz)
+function makeNumberInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateNumberInputField(horz);
 
 	if setting.inputType == 'float' then

--- a/mods/libs/AutoSettingsFiles/code/Client_PresentConfigureUI.lua
+++ b/mods/libs/AutoSettingsFiles/code/Client_PresentConfigureUI.lua
@@ -255,9 +255,9 @@ function cpcDoSetting(setting, vert)
 		createHelpBtn(horz, vert2, setting);
 
 		if setting.inputType == 'text' then
-			makeTextInput(setting, horz);
+			makeTextInput(setting, horz, initialSettingValue);
 		elseif setting.inputType == 'int' or setting.inputType == 'float' then
-			makeNumberInput(setting, horz);
+			makeNumberInput(setting, horz, initialSettingValue);
 		end
 	end
 end
@@ -388,7 +388,7 @@ function cpcDoSettingBoolSubsettings(setting, horz, vert)
 	subsettingEnabledOrDisabled();
 end
 
-function makeTextInput(setting, horz)
+function makeTextInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateTextInputField(horz).SetText(initialSettingValue);
 
 	if setting.placeholder then
@@ -400,7 +400,7 @@ function makeTextInput(setting, horz)
 	end
 end
 
-function makeNumberInput(setting, horz)
+function makeNumberInput(setting, horz, initialSettingValue)
 	GLOBALS[setting.name] = UI.CreateNumberInputField(horz);
 
 	if setting.inputType == 'float' then


### PR DESCRIPTION
Fixes a runtime error when trying to read setting values in Client_PresentConfigureUI for input types `'int'`, `'float'` and `'text'`, which was introduced in Commit 8c3249f