### PR TITLE
Mystery Card update

### DIFF
--- a/mods/Mystery Card/Client_GameRefresh.lua
+++ b/mods/Mystery Card/Client_GameRefresh.lua
@@ -30,7 +30,7 @@ function createDialog(game)
 	local dialog = {};
 
 	game.CreateDialog(function(rootParent, setMaxSize, setScrollable, clientGame, close)
-		setMaxSize(200, 200);
+		setMaxSize(350, 200);
 		setScrollable(false, true);
 
 		local vert = Vert(rootParent);

--- a/mods/Mystery Card/Server_AdvanceTurn.lua
+++ b/mods/Mystery Card/Server_AdvanceTurn.lua
@@ -86,8 +86,8 @@ function getCardName(cardGame)
 	if cardGame.proxyType == 'CardGameAbandon' then
 		-- Abandon card was the original name of the Emergency Blockade card
 
-		return 'Emergency Blockade card';
+		return 'Emergency Blockade Card';
 	end
 
-	return cardGame.proxyType:gsub('^CardGame', ''):gsub('(%l)(%u)', '%1 %2') .. ' card';
+	return cardGame.proxyType:gsub('^CardGame', ''):gsub('(%l)(%u)', '%1 %2') .. ' Card';
 end

--- a/mods/Mystery Card/Server_AdvanceTurn.lua
+++ b/mods/Mystery Card/Server_AdvanceTurn.lua
@@ -78,9 +78,7 @@ end
 
 function getCardName(cardGame)
 	if cardGame.proxyType == 'CardGameCustom' then
-		-- currently no standard way to get custom card name
-
-		return 'card';
+		return cardGame.Name;
 	end
 
 	if cardGame.proxyType == 'CardGameAbandon' then

--- a/mods/Mystery Card/Server_AdvanceTurn.lua
+++ b/mods/Mystery Card/Server_AdvanceTurn.lua
@@ -48,7 +48,7 @@ function Server_AdvanceTurn_Order(game, order, orderResult, skipThisOrder, addNe
 	local event = WL.GameOrderEvent.Create(playerId, 'Receive a full ' .. randomCard.name .. ' from playing a Mystery Card', {});
 	local piecesInRandomCard = game.Settings.Cards[randomCard.id].NumPieces;
 
-	event.addAddCardPiecesOpt = {[playerId] = {[randomCardId] = piecesInRandomCard}};
+	event.AddCardPiecesOpt = {[playerId] = {[randomCard.id] = piecesInRandomCard}};
 	addNewOrder(event, true);
 end
 

--- a/mods/Mystery Card/Server_AdvanceTurn.lua
+++ b/mods/Mystery Card/Server_AdvanceTurn.lua
@@ -68,11 +68,12 @@ function getCards(game)
 		if cardId ~= Mod.Settings.MysteryCardID then
 			-- exclude Mystery Card
 
-			table.insert({id = cardId, name = getCardName(cardGame)});
+			table.insert(cards, {id = cardId, name = getCardName(cardGame)});
 		end
 	end
 
-	Mod.PublicGameData.cards = cards;
+	pgd.cards = cards;
+	Mod.PublicGameData = pgd;
 end
 
 function getCardName(cardGame)

--- a/mods/Mystery Card/Server_AdvanceTurn.lua
+++ b/mods/Mystery Card/Server_AdvanceTurn.lua
@@ -25,7 +25,7 @@ function Server_AdvanceTurn_Order(game, order, orderResult, skipThisOrder, addNe
 		return;
 	end
 
-	local player = game.ServerGame.Players[playerId];
+	local player = game.ServerGame.Game.Players[playerId];
 
 	if not player then
 		addNewOrder(WL.GameOrderEvent.Create(playerId, 'Tried to play a Mystery Card even though they are not in the game'), true);

--- a/mods/Mystery Card/__settings.lua
+++ b/mods/Mystery Card/__settings.lua
@@ -31,7 +31,7 @@ function getSettings()
 						Label(parent).SetText('How common the card is');
 					end
 				}),
-				addSetting('MinimumPiecesPerTurn', 'Minimum pieces awarded per turn', 'int', 8, {
+				addSetting('MinimumPiecesPerTurn', 'Minimum pieces awarded per turn', 'int', 1, {
 					minValue = 0,
 					maxValue = 5,
 					absoluteMax = 1000


### PR DESCRIPTION
- prevent vertical scrollbar from appearing when alerting if app version does not support custom cards
- change default 'Minimum pieces awarded per turn' to 1 instead of 8
- correctly write to `Mod.PublicGameData` when calling `getCards`
- correctly access players
- correctly add card pieces when mystery card played
- capitalize C in Card as that's how order messages are displayed for built-in cards
- use custom card name instead of just 'card' if playing a Mystery Card results in a custom card being rewarded