### PR TITLE
apply latest version of lib version to Swap Territories 2

### DIFF
--- a/mods/Swap Territories 2/__mod.lua
+++ b/mods/Swap Territories 2/__mod.lua
@@ -1,0 +1,9 @@
+-- modified from https://github.com/DanWaLes/Warzone/tree/master/mods/libs/version
+
+-- https://www.warzone.com/wiki/Mod_API_Reference#Newer_API_features
+
+MOD = {
+	name = 'Swap Territories 2',
+	clientVersion = '5.17',
+	serverVersion = '5.24.1'
+};

--- a/mods/Swap Territories 2/version.lua
+++ b/mods/Swap Territories 2/version.lua
@@ -1,13 +1,43 @@
--- https://www.warzone.com/wiki/Mod_API_Reference:CustomSpecialUnit
+-- copied from https://github.com/DanWaLes/Warzone/tree/master/mods/libs/version
+
+require('__mod');
+
+local function isVersionOrHigher(version)
+	return WL and WL.IsVersionOrHigher and WL.IsVersionOrHigher(version);
+end
+
+local function err(msg)
+	local alert = (UI and UI.Alert) or error;
+
+	if type(alert) == 'function' then
+		alert(msg);
+	end
+end
 
 function canRunMod()
-	local version = '5.24.1';
-	local name = '"Swap Territories 3"';
+	-- for use on client hooks
+	-- not needed in Client_PresentSettingsUI in AutoSettingsFiles due to checking for 5.21
+	-- if is under 5.21 then UI.Destroy and UI.IsDestroyed are never called
 
-	if (not WL.IsVersionOrHigher or not WL.IsVersionOrHigher(version)) then
-		UI.Alert('You must be running app version ' + version + ' at the minimum to use mod ' + name + '. Check for updates');
-		return;
+	if isVersionOrHigher(MOD.clientVersion) then
+		return true;
 	end
 
+	err('You must be running app version ' .. MOD.clientVersion .. ' at the minimum to use the mod "' .. MOD.name .. '". Check for updates.');
+
+	return false;
+end
+
+function serverCanRunMod(game)
+	-- for use on server hooks
+
+	if game.Settings.SinglePlayer and not isVersionOrHigher(MOD.serverVersion) then
+		-- in single player games the server is the client. client version of mod api framework might not be up to date
+		err('You must be running app version ' .. MOD.serverVersion .. ' at the minimum to use the mod "' .. MOD.name .. '" in single player. Check for updates.');
+
+		return false;
+	end
+
+	-- server always runs most up to date version of mod api framework
 	return true;
 end


### PR DESCRIPTION
the mod does didnt use the latest code for that dependency but calls serverCanRunMod anyway, which causes a crash. the appropriate files were not created/updated when latest version of lib version updated and applied to mods