### PR TITLE
Map testing - territory connections update

### DIFF
--- a/mods/Map testing - territory connections/Client_PresentMenuUI.lua
+++ b/mods/Map testing - territory connections/Client_PresentMenuUI.lua
@@ -8,10 +8,12 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game, close
 
 	local vert = Vert(rootParent);
 
-	if not debug and not game.Settings.MapTestingGame then
-		Label(vert).SetText('This mod can only be used in map testing games');
+	if not game.Settings.MapTestingGame then
+		if not debug then
+			Label(vert).SetText('This mod can only be used in map testing games');
 
-		return;
+			return;
+		end
 	end
 
 	local numTerrs = #Mod.PublicGameData.terrNames;

--- a/mods/Map testing - territory connections/Client_PresentMenuUI.lua
+++ b/mods/Map testing - territory connections/Client_PresentMenuUI.lua
@@ -1,12 +1,14 @@
 require('tblprint');
 require('ui');
 
+local debug = false;
+
 function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game, close)
 	setMaxSize(400, 200);
 
 	local vert = Vert(rootParent);
 
-	if not game.Settings.MapTestingGame then
+	if not debug and not game.Settings.MapTestingGame then
 		Label(vert).SetText('This mod can only be used in map testing games');
 
 		return;

--- a/mods/Map testing - territory connections/Server_AdvanceTurn.lua
+++ b/mods/Map testing - territory connections/Server_AdvanceTurn.lua
@@ -5,12 +5,16 @@ local canRun = nil;
 local doneSkippingTurn1 = false;
 local debug = false;
 
-function Server_AdvanceTurn_Order(game, order, result, skipThisOrder)
+function CanRun(game)
 	if canRun == nil then
 		canRun = serverCanRunMod(game);
 	end
 
-	if not canRun then
+	return canRun;
+end
+
+function Server_AdvanceTurn_Order(game, order, result, skipThisOrder)
+	if not CanRun(game) then
 		return;
 	end
 
@@ -27,7 +31,7 @@ function Server_AdvanceTurn_Order(game, order, result, skipThisOrder)
 end
 
 function Server_AdvanceTurn_End(game, addNewOrder)
-	if not canRun then
+	if not CanRun(game) then
 		return;
 	end
 

--- a/mods/Map testing - territory connections/Server_AdvanceTurn.lua
+++ b/mods/Map testing - territory connections/Server_AdvanceTurn.lua
@@ -3,13 +3,14 @@ require('version');
 
 local canRun = nil;
 local doneSkippingTurn1 = false;
+local debug = false;
 
 function Server_AdvanceTurn_Order(game, order, result, skipThisOrder)
 	if canRun == nil then
 		canRun = serverCanRunMod(game);
 	end
 
-	if not game.Settings.MapTestingGame or not canRun then
+	if (not debug and not game.Settings.MapTestingGame) or not canRun then
 		return;
 	end
 
@@ -20,7 +21,7 @@ function Server_AdvanceTurn_Order(game, order, result, skipThisOrder)
 end
 
 function Server_AdvanceTurn_End(game, addNewOrder)
-	if not game.Settings.MapTestingGame or not canRun then
+	if (not debug and not game.Settings.MapTestingGame) or not canRun then
 		return;
 	end
 

--- a/mods/Map testing - territory connections/Server_AdvanceTurn.lua
+++ b/mods/Map testing - territory connections/Server_AdvanceTurn.lua
@@ -10,8 +10,14 @@ function Server_AdvanceTurn_Order(game, order, result, skipThisOrder)
 		canRun = serverCanRunMod(game);
 	end
 
-	if (not debug and not game.Settings.MapTestingGame) or not canRun then
+	if not canRun then
 		return;
+	end
+
+	if not game.Settings.MapTestingGame then
+		if not debug then
+			return;
+		end
 	end
 
 	if game.ServerGame.Game.TurnNumber == 1 and not doneSkippingTurn1 then
@@ -21,8 +27,14 @@ function Server_AdvanceTurn_Order(game, order, result, skipThisOrder)
 end
 
 function Server_AdvanceTurn_End(game, addNewOrder)
-	if (not debug and not game.Settings.MapTestingGame) or not canRun then
+	if not canRun then
 		return;
+	end
+
+	if not game.Settings.MapTestingGame then
+		if not debug then
+			return;
+		end
 	end
 
 	if game.ServerGame.Game.TurnNumber == 1 then

--- a/mods/Map testing - territory connections/Server_AdvanceTurn.lua
+++ b/mods/Map testing - territory connections/Server_AdvanceTurn.lua
@@ -78,7 +78,7 @@ function makeDeployments(game, addNewOrder)
 		n = n + 1;
 	end
 
-	addNewOrder(WL.GameOrderEvent.Create(WL.PlayerID.Neutral, 'Made deployments', nil, mods));
+	addNewOrder(WL.GameOrderEvent.Create(WL.PlayerID.Neutral, 'Deployments', nil, mods));
 end
 
 function numConnectionsWithPlayers(game, attackFromN)

--- a/mods/Map testing - territory connections/Server_Created.lua
+++ b/mods/Map testing - territory connections/Server_Created.lua
@@ -1,8 +1,10 @@
 require('tblprint');
 require('version');
 
+local debug = false;
+
 function Server_Created(game, settings)
-	if not settings.MapTestingGame then
+	if not debug and not settings.MapTestingGame then
 		return;
 	end
 

--- a/mods/Map testing - territory connections/Server_Created.lua
+++ b/mods/Map testing - territory connections/Server_Created.lua
@@ -4,8 +4,10 @@ require('version');
 local debug = false;
 
 function Server_Created(game, settings)
-	if not debug and not settings.MapTestingGame then
-		return;
+	if not settings.MapTestingGame then
+		if not debug then
+			return;
+		end
 	end
 
 	if not serverCanRunMod(game) then

--- a/mods/Map testing - territory connections/Server_Created.lua
+++ b/mods/Map testing - territory connections/Server_Created.lua
@@ -63,5 +63,8 @@ function listTerritoryNamesAlphabetically(game)
 		return a.name < b.name;
 	end);
 
-	Mod.PublicGameData = {terrNames = names};
+	local pgd = Mod.PublicGameData;
+
+	pgd.terrNames = names;
+	Mod.PublicGameData = pgd;
 end

--- a/mods/Map testing - territory connections/Server_StartGame.lua
+++ b/mods/Map testing - territory connections/Server_StartGame.lua
@@ -4,8 +4,10 @@ require('version');
 local debug = false;
 
 function Server_StartGame(game, standing)
-	if not debug and not game.Settings.MapTestingGame then
-		return;
+	if game.Settings.MapTestingGame then
+		if not debug then
+			return;
+		end
 	end
 
 	if not serverCanRunMod(game) then

--- a/mods/Map testing - territory connections/Server_StartGame.lua
+++ b/mods/Map testing - territory connections/Server_StartGame.lua
@@ -1,8 +1,10 @@
 require('tblprint');
 require('version');
 
+local debug = false;
+
 function Server_StartGame(game, standing)
-	if not game.Settings.MapTestingGame then
+	if not debug and not game.Settings.MapTestingGame then
 		return;
 	end
 


### PR DESCRIPTION
Add debug mode which bypasses map must be in testing phase requirement
Make sure `canRun` is initialized before trying to use it in Server_AdvanceTurn_End