### PR TITLE
Lib auto settings files bug fix

### DIFF
--- a/mods/AIs dont attack/Client_SaveConfigureUI.lua
+++ b/mods/AIs dont attack/Client_SaveConfigureUI.lua
@@ -51,19 +51,21 @@ function Client_SaveConfigureUI(alert, addCard)
 		return value;
 	end
 
-	for _, setting in ipairs(customCardSettings) do
-		local cardId = addCard(
-			setting.customCardName,
-			setting.customCardDescription,
-			setting.customCardImageFilename,
-			getCardGameSetting(setting, 'NumPieces'),
-			getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
-			getCardGameSetting(setting, 'InitialPieces'),
-			getCardGameSetting(setting, 'Weight'),
-			getCardGameSetting(setting, 'ActiveOrderDuration')
-		);
+	if type(addCard) == 'function' then
+		for _, setting in ipairs(customCardSettings) do
+			local cardId = addCard(
+				setting.customCardName,
+				setting.customCardDescription,
+				setting.customCardImageFilename,
+				getCardGameSetting(setting, 'NumPieces'),
+				getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
+				getCardGameSetting(setting, 'InitialPieces'),
+				getCardGameSetting(setting, 'Weight'),
+				getCardGameSetting(setting, 'ActiveOrderDuration')
+			);
 
-		Mod.Settings[setting.name] = cardId;
+			Mod.Settings[setting.name] = cardId;
+		end
 	end
 
 	return true;

--- a/mods/Advanced Card Distribution per player/Client_SaveConfigureUI.lua
+++ b/mods/Advanced Card Distribution per player/Client_SaveConfigureUI.lua
@@ -51,19 +51,21 @@ function Client_SaveConfigureUI(alert, addCard)
 		return value;
 	end
 
-	for _, setting in ipairs(customCardSettings) do
-		local cardId = addCard(
-			setting.customCardName,
-			setting.customCardDescription,
-			setting.customCardImageFilename,
-			getCardGameSetting(setting, 'NumPieces'),
-			getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
-			getCardGameSetting(setting, 'InitialPieces'),
-			getCardGameSetting(setting, 'Weight'),
-			getCardGameSetting(setting, 'ActiveOrderDuration')
-		);
+	if type(addCard) == 'function' then
+		for _, setting in ipairs(customCardSettings) do
+			local cardId = addCard(
+				setting.customCardName,
+				setting.customCardDescription,
+				setting.customCardImageFilename,
+				getCardGameSetting(setting, 'NumPieces'),
+				getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
+				getCardGameSetting(setting, 'InitialPieces'),
+				getCardGameSetting(setting, 'Weight'),
+				getCardGameSetting(setting, 'ActiveOrderDuration')
+			);
 
-		Mod.Settings[setting.name] = cardId;
+			Mod.Settings[setting.name] = cardId;
+		end
 	end
 
 	return true;

--- a/mods/Custom Card Package 2/Client_SaveConfigureUI.lua
+++ b/mods/Custom Card Package 2/Client_SaveConfigureUI.lua
@@ -51,19 +51,21 @@ function Client_SaveConfigureUI(alert, addCard)
 		return value;
 	end
 
-	for _, setting in ipairs(customCardSettings) do
-		local cardId = addCard(
-			setting.customCardName,
-			setting.customCardDescription,
-			setting.customCardImageFilename,
-			getCardGameSetting(setting, 'NumPieces'),
-			getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
-			getCardGameSetting(setting, 'InitialPieces'),
-			getCardGameSetting(setting, 'Weight'),
-			getCardGameSetting(setting, 'ActiveOrderDuration')
-		);
+	if type(addCard) == 'function' then
+		for _, setting in ipairs(customCardSettings) do
+			local cardId = addCard(
+				setting.customCardName,
+				setting.customCardDescription,
+				setting.customCardImageFilename,
+				getCardGameSetting(setting, 'NumPieces'),
+				getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
+				getCardGameSetting(setting, 'InitialPieces'),
+				getCardGameSetting(setting, 'Weight'),
+				getCardGameSetting(setting, 'ActiveOrderDuration')
+			);
 
-		Mod.Settings[setting.name] = cardId;
+			Mod.Settings[setting.name] = cardId;
+		end
 	end
 
 	return true;

--- a/mods/Mystery Card/Client_SaveConfigureUI.lua
+++ b/mods/Mystery Card/Client_SaveConfigureUI.lua
@@ -51,19 +51,21 @@ function Client_SaveConfigureUI(alert, addCard)
 		return value;
 	end
 
-	for _, setting in ipairs(customCardSettings) do
-		local cardId = addCard(
-			setting.customCardName,
-			setting.customCardDescription,
-			setting.customCardImageFilename,
-			getCardGameSetting(setting, 'NumPieces'),
-			getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
-			getCardGameSetting(setting, 'InitialPieces'),
-			getCardGameSetting(setting, 'Weight'),
-			getCardGameSetting(setting, 'ActiveOrderDuration')
-		);
+	if type(addCard) == 'function' then
+		for _, setting in ipairs(customCardSettings) do
+			local cardId = addCard(
+				setting.customCardName,
+				setting.customCardDescription,
+				setting.customCardImageFilename,
+				getCardGameSetting(setting, 'NumPieces'),
+				getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
+				getCardGameSetting(setting, 'InitialPieces'),
+				getCardGameSetting(setting, 'Weight'),
+				getCardGameSetting(setting, 'ActiveOrderDuration')
+			);
 
-		Mod.Settings[setting.name] = cardId;
+			Mod.Settings[setting.name] = cardId;
+		end
 	end
 
 	return true;

--- a/mods/Random settings generator/Client_SaveConfigureUI.lua
+++ b/mods/Random settings generator/Client_SaveConfigureUI.lua
@@ -51,19 +51,21 @@ function Client_SaveConfigureUI(alert, addCard)
 		return value;
 	end
 
-	for _, setting in ipairs(customCardSettings) do
-		local cardId = addCard(
-			setting.customCardName,
-			setting.customCardDescription,
-			setting.customCardImageFilename,
-			getCardGameSetting(setting, 'NumPieces'),
-			getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
-			getCardGameSetting(setting, 'InitialPieces'),
-			getCardGameSetting(setting, 'Weight'),
-			getCardGameSetting(setting, 'ActiveOrderDuration')
-		);
+	if type(addCard) == 'function' then
+		for _, setting in ipairs(customCardSettings) do
+			local cardId = addCard(
+				setting.customCardName,
+				setting.customCardDescription,
+				setting.customCardImageFilename,
+				getCardGameSetting(setting, 'NumPieces'),
+				getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
+				getCardGameSetting(setting, 'InitialPieces'),
+				getCardGameSetting(setting, 'Weight'),
+				getCardGameSetting(setting, 'ActiveOrderDuration')
+			);
 
-		Mod.Settings[setting.name] = cardId;
+			Mod.Settings[setting.name] = cardId;
+		end
 	end
 
 	return true;

--- a/mods/Surveillance Card+/Client_SaveConfigureUI.lua
+++ b/mods/Surveillance Card+/Client_SaveConfigureUI.lua
@@ -51,19 +51,21 @@ function Client_SaveConfigureUI(alert, addCard)
 		return value;
 	end
 
-	for _, setting in ipairs(customCardSettings) do
-		local cardId = addCard(
-			setting.customCardName,
-			setting.customCardDescription,
-			setting.customCardImageFilename,
-			getCardGameSetting(setting, 'NumPieces'),
-			getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
-			getCardGameSetting(setting, 'InitialPieces'),
-			getCardGameSetting(setting, 'Weight'),
-			getCardGameSetting(setting, 'ActiveOrderDuration')
-		);
+	if type(addCard) == 'function' then
+		for _, setting in ipairs(customCardSettings) do
+			local cardId = addCard(
+				setting.customCardName,
+				setting.customCardDescription,
+				setting.customCardImageFilename,
+				getCardGameSetting(setting, 'NumPieces'),
+				getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
+				getCardGameSetting(setting, 'InitialPieces'),
+				getCardGameSetting(setting, 'Weight'),
+				getCardGameSetting(setting, 'ActiveOrderDuration')
+			);
 
-		Mod.Settings[setting.name] = cardId;
+			Mod.Settings[setting.name] = cardId;
+		end
 	end
 
 	return true;

--- a/mods/Swap Territories 2/Client_SaveConfigureUI.lua
+++ b/mods/Swap Territories 2/Client_SaveConfigureUI.lua
@@ -51,19 +51,21 @@ function Client_SaveConfigureUI(alert, addCard)
 		return value;
 	end
 
-	for _, setting in ipairs(customCardSettings) do
-		local cardId = addCard(
-			setting.customCardName,
-			setting.customCardDescription,
-			setting.customCardImageFilename,
-			getCardGameSetting(setting, 'NumPieces'),
-			getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
-			getCardGameSetting(setting, 'InitialPieces'),
-			getCardGameSetting(setting, 'Weight'),
-			getCardGameSetting(setting, 'ActiveOrderDuration')
-		);
+	if type(addCard) == 'function' then
+		for _, setting in ipairs(customCardSettings) do
+			local cardId = addCard(
+				setting.customCardName,
+				setting.customCardDescription,
+				setting.customCardImageFilename,
+				getCardGameSetting(setting, 'NumPieces'),
+				getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
+				getCardGameSetting(setting, 'InitialPieces'),
+				getCardGameSetting(setting, 'Weight'),
+				getCardGameSetting(setting, 'ActiveOrderDuration')
+			);
 
-		Mod.Settings[setting.name] = cardId;
+			Mod.Settings[setting.name] = cardId;
+		end
 	end
 
 	return true;

--- a/mods/Wastelands+/Client_SaveConfigureUI.lua
+++ b/mods/Wastelands+/Client_SaveConfigureUI.lua
@@ -51,19 +51,21 @@ function Client_SaveConfigureUI(alert, addCard)
 		return value;
 	end
 
-	for _, setting in ipairs(customCardSettings) do
-		local cardId = addCard(
-			setting.customCardName,
-			setting.customCardDescription,
-			setting.customCardImageFilename,
-			getCardGameSetting(setting, 'NumPieces'),
-			getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
-			getCardGameSetting(setting, 'InitialPieces'),
-			getCardGameSetting(setting, 'Weight'),
-			getCardGameSetting(setting, 'ActiveOrderDuration')
-		);
+	if type(addCard) == 'function' then
+		for _, setting in ipairs(customCardSettings) do
+			local cardId = addCard(
+				setting.customCardName,
+				setting.customCardDescription,
+				setting.customCardImageFilename,
+				getCardGameSetting(setting, 'NumPieces'),
+				getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
+				getCardGameSetting(setting, 'InitialPieces'),
+				getCardGameSetting(setting, 'Weight'),
+				getCardGameSetting(setting, 'ActiveOrderDuration')
+			);
 
-		Mod.Settings[setting.name] = cardId;
+			Mod.Settings[setting.name] = cardId;
+		end
 	end
 
 	return true;

--- a/mods/libs/AutoSettingsFiles/code/Client_SaveConfigureUI.lua
+++ b/mods/libs/AutoSettingsFiles/code/Client_SaveConfigureUI.lua
@@ -51,19 +51,21 @@ function Client_SaveConfigureUI(alert, addCard)
 		return value;
 	end
 
-	for _, setting in ipairs(customCardSettings) do
-		local cardId = addCard(
-			setting.customCardName,
-			setting.customCardDescription,
-			setting.customCardImageFilename,
-			getCardGameSetting(setting, 'NumPieces'),
-			getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
-			getCardGameSetting(setting, 'InitialPieces'),
-			getCardGameSetting(setting, 'Weight'),
-			getCardGameSetting(setting, 'ActiveOrderDuration')
-		);
+	if type(addCard) == 'function' then
+		for _, setting in ipairs(customCardSettings) do
+			local cardId = addCard(
+				setting.customCardName,
+				setting.customCardDescription,
+				setting.customCardImageFilename,
+				getCardGameSetting(setting, 'NumPieces'),
+				getCardGameSetting(setting, 'MinimumPiecesPerTurn'),
+				getCardGameSetting(setting, 'InitialPieces'),
+				getCardGameSetting(setting, 'Weight'),
+				getCardGameSetting(setting, 'ActiveOrderDuration')
+			);
 
-		Mod.Settings[setting.name] = cardId;
+			Mod.Settings[setting.name] = cardId;
+		end
 	end
 
 	return true;


### PR DESCRIPTION
prevent `addCard` from being called if Client_SaveConfigure called from Client_PresentConfigureUI
before this fix, collapsing settings that contain custom cards resulted in a crash
apply fix to all mods